### PR TITLE
Fix copy error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By default, this argument is set to `DynCapacity`. You can change this to `Const
 To create a `QuadTree` you can use one of three methods
 1. new_with_capacity takes a `Boundary` and parameter of type `Capacity`.
 2. new_with_dyn_cap takes a `Boundary` and a capacity of type usize. This function is only available if the capacity is dynamic.
-3. new_with_dyn_cap takes a `Boundary`. This function is only available if the capacity is known at compile time.
+3. new_with_const_cap takes a `Boundary`. This function is only available if the capacity is known at compile time.
 
 ### Insert
 An item can be inserted using the `insert` function. This function requires for item to implement `AsPoint`.


### PR DESCRIPTION
`new_with_const_cap` was labelled as `new_with_dyn_cap`