### PR TITLE
feat: Meet api interoperability guidelines

### DIFF
--- a/src/boundary.rs
+++ b/src/boundary.rs
@@ -13,7 +13,7 @@ pub trait Area<C: Coordinate>: Clone {
 }
 
 /// A rectangular area
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Boundary<C>
 where
     C: Coordinate,

--- a/src/boundary.rs
+++ b/src/boundary.rs
@@ -107,7 +107,7 @@ where
         let half_dx = dx / two;
         let half_dy = dy / two;
         [
-            Boundary::new(self.p1.clone(), half_dx, half_dy),
+            Boundary::new(self.p1, half_dx, half_dy),
             Boundary::between_points_unchecked(
                 (self.p1.x + half_dx, self.p1.y),
                 (self.p2.x, self.p1.y + half_dy),
@@ -116,10 +116,7 @@ where
                 (self.p1.x, self.p1.y + half_dy),
                 (self.p1.x + half_dx, self.p2.y),
             ),
-            Boundary::between_points_unchecked(
-                (self.p1.x + half_dx, self.p1.y + half_dy),
-                self.p2.clone(),
-            ),
+            Boundary::between_points_unchecked((self.p1.x + half_dx, self.p1.y + half_dy), self.p2),
         ]
     }
 

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -3,7 +3,7 @@ pub trait Capacity: Clone + Copy {
 }
 
 /// A Capacity known at compile time
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct ConstCap<const CAP: usize>;
 impl<const CAP: usize> Capacity for ConstCap<CAP> {
     #[inline]
@@ -13,7 +13,7 @@ impl<const CAP: usize> Capacity for ConstCap<CAP> {
 }
 
 /// A Capacity known at runtime
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct DynCap(pub(super) usize);
 impl Capacity for DynCap {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use iter::*;
 /// C: The type used for coordinates
 /// Item: The type to be saved
 /// CAP: The maximum capacity of each level
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct QuadTree<C, Item, Cap = DynCap>
 where
     C: Coordinate,
@@ -56,7 +56,7 @@ where
 }
 
 /// Possible errors
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq, Clone)]
 pub enum QuadTreeError<C>
 where
     C: Coordinate,
@@ -75,7 +75,7 @@ where
 }
 
 /// A point in two dimensional space
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Point<C>
 where
     C: Coordinate,
@@ -179,7 +179,6 @@ where
     pub fn capacity(&self) -> usize {
         self.capacity.capacity()
     }
-
 }
 
 impl<C, Item, Cap> QuadTree<C, Item, Cap>


### PR DESCRIPTION
interoperability guidelines: https://rust-lang.github.io/api-guidelines/interoperability.html

I've added derives for `Eq`, `Copy`, and `Clone` where possible, and for `Ord` where it didn't seem misleading (i.e. no `Ord` on `Point` because it's 2d, but trivial `Ord` on `ConstCap`).
I added derives for `Hash` for `Point` and `Boundary`, which I thought could hypothetically be used as sensible keys for some structure, and for the capacity types, which could hypothetically be nested within a sensible key, but not e.g. `QuadTree`, the iterators, or the error.